### PR TITLE
Unschedule build to avoid it getting disabled

### DIFF
--- a/.github/workflows/build_pages_native.yml
+++ b/.github/workflows/build_pages_native.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
     branches:
       - main
-  schedule:
-    - cron: "15 3 * * *"
+#  schedule:
+#    - cron: "15 3 * * *"
 
 jobs:
   build_and_test:


### PR DESCRIPTION
Scheduled builds are disabled if a repo is inactive for 60 days or more. That's not what we want